### PR TITLE
Pretty urls

### DIFF
--- a/canonicalwebteam/discourse_docs/app.py
+++ b/canonicalwebteam/discourse_docs/app.py
@@ -71,7 +71,10 @@ class DiscourseDocs(object):
 
                 document = parse_topic(topic)
 
-                if document["topic_path"] != path:
+                if (
+                    topic_id not in index["url_map"]
+                    and document["topic_path"] != path
+                ):
                     return flask.redirect(document["topic_path"])
 
             return flask.render_template(

--- a/canonicalwebteam/discourse_docs/app.py
+++ b/canonicalwebteam/discourse_docs/app.py
@@ -1,7 +1,10 @@
 import flask
 from requests.exceptions import HTTPError
 
-from canonicalwebteam.discourse_docs.exceptions import PathNotFoundError
+from canonicalwebteam.discourse_docs.exceptions import (
+    PathNotFoundError,
+    RedirectFoundError,
+)
 from canonicalwebteam.discourse_docs.parsers import (
     parse_topic,
     parse_index,
@@ -49,7 +52,9 @@ class DiscourseDocs(object):
                 document = index
             else:
                 try:
-                    topic_id = resolve_path(path)
+                    topic_id = resolve_path(path, index["url_map"])
+                except RedirectFoundError as redirect:
+                    return flask.redirect(redirect.target_url)
                 except PathNotFoundError:
                     return flask.abort(404)
 

--- a/canonicalwebteam/discourse_docs/exceptions.py
+++ b/canonicalwebteam/discourse_docs/exceptions.py
@@ -10,3 +10,18 @@ class PathNotFoundError(Exception):
             message = f"Path {path} not found"
 
         super().__init__(message, *args, **kwargs)
+
+
+class RedirectFoundError(Exception):
+    """
+    If we encounter redirects from Discourse, we need to take action
+    """
+
+    def __init__(self, path, target_url, *args, message=None, **kwargs):
+        self.path = path
+        self.target_url = target_url
+
+        if not message:
+            message = f"Path {path} has moved to {target_url}"
+
+        super().__init__(*args, **kwargs)

--- a/canonicalwebteam/discourse_docs/parsers.py
+++ b/canonicalwebteam/discourse_docs/parsers.py
@@ -135,7 +135,40 @@ def parse_navigation(index_soup, url_map):
 def parse_url_map(index_soup):
     """
     Given the HTML soup of an index topic
-    extract the URL mappings from the "URLs" section
+    extract the URL mappings from the "URLs" section.
+
+    The URLs section should contain a table of
+    "Topic" to "Path" mappings
+    (extra markup around this table doesn't matter)
+    e.g.:
+
+      <h1>URLs</h1>
+      <details>
+        <summary>Mapping table</summary>
+        <table>
+          <tr><th>Topic</th><th>Path</th></tr>
+          <tr>
+            <td><a href="https://forum.example.com/t/page/10">Page</a></td>
+            <td>/cool-page</td>
+          </tr>
+          <tr>
+            <td><a href="https://forum.example.com/t/place/11">Place</a></td>
+            <td>/cool-place</td>
+          </tr>
+        </table>
+      </details>
+
+    This will typically be generated in Discourse from Markdown similar to
+    the following:
+
+      # URLs
+
+      [details=Mapping table]
+      | Topic | Path |
+      | -- | -- |
+      | https://forum.example.com/t/place/11| /cool-page |
+      | https://forum.example.com/t/place/11  | /cool-place |
+
     """
 
     url_soup = get_section(index_soup, "URLs")

--- a/canonicalwebteam/discourse_docs/parsers.py
+++ b/canonicalwebteam/discourse_docs/parsers.py
@@ -6,7 +6,6 @@ from urllib.parse import urlparse
 import dateutil.parser
 import humanize
 from bs4 import BeautifulSoup
-from bs4.element import NavigableString, Tag
 from jinja2 import Template
 
 # Local
@@ -25,7 +24,7 @@ def resolve_path(path, url_map):
     """
     Given a path to a Discourse topic, and a mapping of
     URLs to IDs and IDs to URLs, resolve the path to a topic ID
-    
+
     A PathNotFoundError will be raised if the path is not recognised.
 
     A RedirectFoundError will be raised if the topic should be
@@ -157,7 +156,7 @@ def parse_url_map(index_soup):
 
             pretty_path = path_td.text
 
-            if not topic_match or not pretty_path.startswith('/'):
+            if not topic_match or not pretty_path.startswith("/"):
                 print("Could not parse URL map item {item}")
                 continue
 

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
         "humanize",
         "python-dateutil",
     ],
-    tests_require=["responses", "requests-mock"],
+    tests_require=["responses", "requests-mock", "httpretty"],
 )

--- a/tests/fixtures/forum_mock.py
+++ b/tests/fixtures/forum_mock.py
@@ -28,7 +28,48 @@ def register_uris():
                                 '<li><a href="/t/page-a/10">Page A</a></li>'
                                 '<li><a href="/t/b-page/12">B page</a></li>'
                                 "</ul>"
+                                "<h1>URLs</h1>"
+                                '<details open="">'
+                                "<summary>Mapping table</summary>"
+                                '<div class="md-table">'
+                                "<table>"
+                                "<thead><tr>"
+                                "<th>Topic</th><th>Path</th></tr></thead>"
+                                "<tbody><tr>"
+                                '<td><a href="https://discourse.example.com/t/'
+                                'page-a/10">Page A</a></td>'
+                                "<td>/a</td>"
+                                "</tr><tr>"
+                                '<td><a href="https://discourse.example.com/t/'
+                                'page-z/26">Page Z</a></td>'
+                                "<td>/page-z</td>"
+                                "</tr></tbody></table>"
+                                "</div></details>"
                             ),
+                            "updated_at": "2018-10-02T12:45:44.259Z",
+                        }
+                    ]
+                },
+            }
+        ),
+        content_type="application/json",
+    )
+
+    # Basic topic page with minimal content
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://discourse.example.com/t/10.json",
+        body=json.dumps(
+            {
+                "id": 10,
+                "category_id": 2,
+                "title": "Page A",
+                "slug": "page-a",
+                "post_stream": {
+                    "posts": [
+                        {
+                            "id": 56,
+                            "cooked": ("<p>Content of this page</p>"),
                             "updated_at": "2018-10-02T12:45:44.259Z",
                         }
                     ]

--- a/tests/fixtures/forum_mock.py
+++ b/tests/fixtures/forum_mock.py
@@ -23,7 +23,7 @@ def register_uris():
                             "id": 3434,
                             "cooked": (
                                 "<p>Some homepage content</p>"
-                                "<h1>Content</h1>"
+                                "<h1>Navigation</h1>"
                                 "<ul>"
                                 '<li><a href="/t/page-a/10">Page A</a></li>'
                                 '<li><a href="/t/b-page/12">B page</a></li>'

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -85,7 +85,7 @@ class TestDiscourseAPI(unittest.TestCase):
 
         # Check navigation
         self.assertNotIn(
-            "<h1>Content</h1>", soup.find("main").decode_contents()
+            "<h1>Navigation</h1>", soup.find("main").decode_contents()
         )
         self.assertNotIn(
             '<a href="/t/page-a/10">Page A</a>',
@@ -211,7 +211,7 @@ class TestDiscourseAPI(unittest.TestCase):
         )
 
         self.assertIn(
-            "<h1>Content</h1>", soup_2.find("main").decode_contents()
+            "<h1>Navigation</h1>", soup_2.find("main").decode_contents()
         )
 
     def test_note_to_editors(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -155,42 +155,41 @@ class TestDiscourseAPI(unittest.TestCase):
             soup.find("nav").decode_contents(),
         )
 
-    def test_redirects(self):
+    def test_homepage_redirects(self):
         """
-        Check links to documents without the correct slug
-        will redirect to the correct path.
-        If the index topic is requested, it should redirect to /
+        Check that if the index topic is requested
+        at a different URL, it redirects to /
         """
 
-        response_1 = self.client.get("/t/some-slug/42")
-        response_2 = self.client.get("/t/42")
-        response_3 = self.client.get("/some-slug/42")
-        response_4 = self.client.get("/42")
-
-        response_5 = self.client.get("/t/some-slug/34")
-        response_6 = self.client.get("/t/34")
-        response_7 = self.client.get("/some-slug/34")
-        response_8 = self.client.get("/34")
-
-        response_9 = self.client.get("/t/page-a/10")
-        response_10 = self.client.get("/t/10")
-        response_11 = self.client.get("/page-a/10")
-        response_12 = self.client.get("/10")
+        response_1 = self.client.get("/t/some-slug/34")
+        response_2 = self.client.get("/t/34")
+        response_3 = self.client.get("/some-slug/34")
+        response_4 = self.client.get("/34")
 
         self.assertEqual(response_1.status_code, 302)
         self.assertEqual(response_2.status_code, 302)
         self.assertEqual(response_3.status_code, 302)
         self.assertEqual(response_4.status_code, 302)
 
-        self.assertEqual(response_5.status_code, 302)
-        self.assertEqual(response_6.status_code, 302)
-        self.assertEqual(response_7.status_code, 302)
-        self.assertEqual(response_8.status_code, 302)
+        self.assertEqual(response_1.headers["location"], "http://localhost/")
+        self.assertEqual(response_2.headers["location"], "http://localhost/")
+        self.assertEqual(response_3.headers["location"], "http://localhost/")
+        self.assertEqual(response_4.headers["location"], "http://localhost/")
 
-        self.assertEqual(response_9.status_code, 302)
-        self.assertEqual(response_10.status_code, 302)
-        self.assertEqual(response_11.status_code, 302)
-        self.assertEqual(response_12.status_code, 302)
+    def test_topic_redirects(self):
+        """
+        Check links to documents without the correct slug
+        will redirect to the correct path
+        """
+        response_1 = self.client.get("/t/some-slug/42")
+        response_2 = self.client.get("/t/42")
+        response_3 = self.client.get("/some-slug/42")
+        response_4 = self.client.get("/42")
+
+        self.assertEqual(response_1.status_code, 302)
+        self.assertEqual(response_2.status_code, 302)
+        self.assertEqual(response_3.status_code, 302)
+        self.assertEqual(response_4.status_code, 302)
 
         self.assertEqual(
             response_1.headers["location"], "http://localhost/t/a-page/42"
@@ -205,15 +204,26 @@ class TestDiscourseAPI(unittest.TestCase):
             response_4.headers["location"], "http://localhost/t/a-page/42"
         )
 
-        self.assertEqual(response_5.headers["location"], "http://localhost/")
-        self.assertEqual(response_6.headers["location"], "http://localhost/")
-        self.assertEqual(response_7.headers["location"], "http://localhost/")
-        self.assertEqual(response_8.headers["location"], "http://localhost/")
+    def test_pretty_url_redirects(self):
+        """
+        Check links to topic paths for a topic that has
+        a pretty URL will redirect to the pretty URL
+        """
 
-        self.assertEqual(response_9.headers["location"], "http://localhost/a")
-        self.assertEqual(response_10.headers["location"], "http://localhost/a")
-        self.assertEqual(response_11.headers["location"], "http://localhost/a")
-        self.assertEqual(response_12.headers["location"], "http://localhost/a")
+        response_1 = self.client.get("/t/page-a/10")
+        response_2 = self.client.get("/t/10")
+        response_3 = self.client.get("/page-a/10")
+        response_4 = self.client.get("/10")
+
+        self.assertEqual(response_1.status_code, 302)
+        self.assertEqual(response_2.status_code, 302)
+        self.assertEqual(response_3.status_code, 302)
+        self.assertEqual(response_4.status_code, 302)
+
+        self.assertEqual(response_1.headers["location"], "http://localhost/a")
+        self.assertEqual(response_2.headers["location"], "http://localhost/a")
+        self.assertEqual(response_3.headers["location"], "http://localhost/a")
+        self.assertEqual(response_4.headers["location"], "http://localhost/a")
 
     def test_document_not_found(self):
         """


### PR DESCRIPTION
Parse a section entitled "URLs" in the index page to create a mapping from pretty URLs to topic IDs and vice-versa.

Then we:
    
- Redirect to the pretty URL
- Replace links to the topic ID with the pretty URL in navigation

This topic is an example of how the URL map looks:
https://forum.snapcraft.io/t/future-index-page/11127

QA
--

This can be QAed using the [`pretty-urls` branch of docs.snapcraft.io](https://github.com/nottrobin/docs.snapcraft.io/tree/pretty-urls) (whose `requirements.txt` points to this branch), as follows:

``` bash
git clone -b pretty-urls https://github.com/nottrobin/docs.snapcraft.io.git docs.snapcraft.io-pretty-urls
cd docs.snapcraft.io-pretty-urls
./run
```

Now go to http://0.0.0.0:8030, and check:

- That all the URLs in the left navigation are "pretty" (as in `/{something}` rather than `/t/{something}/{id}`)
- That if you go to a topic URL, it redirects to the pretty one - e.g. http://0.0.0.0:8030/t/getting-started/3876 -> http://0.0.0.0:8030/getting-started