### PR TITLE
Support "Redirects" in the Index page content

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "beautifulsoup4",
         "humanize",
         "python-dateutil",
+        "validators",
     ],
     tests_require=["responses", "requests-mock", "httpretty"],
 )

--- a/tests/fixtures/forum_mock.py
+++ b/tests/fixtures/forum_mock.py
@@ -7,7 +7,7 @@ def register_uris():
     Mocks for a fake Discourse API set of endpoints
     """
 
-    # Index page with navigation
+    # Index page with navigation, URL map and redirects
     httpretty.register_uri(
         httpretty.GET,
         "https://discourse.example.com/t/34.json",
@@ -44,6 +44,124 @@ def register_uris():
                                 'page-z/26">Page Z</a></td>'
                                 "<td>/page-z</td>"
                                 "</tr></tbody></table>"
+                                "</div></details>"
+                                "<h1>Redirects</h1>"
+                                '<details open="">'
+                                "<summary>Mapping table</summary>"
+                                '<div class="md-table">'
+                                "<table>"
+                                "<thead><tr>"
+                                "<th>Topic</th><th>Path</th></tr></thead>"
+                                "<tbody>"
+                                "<tr><td>/redir-a</td><td>/a</td></tr>"
+                                "<tr>"
+                                "  <td>/example/page</td>"
+                                "  <td>https://example.com/page</td>"
+                                "</tr>"
+                                "</tr></tbody></table>"
+                                "</div></details>"
+                            ),
+                            "updated_at": "2018-10-02T12:45:44.259Z",
+                        }
+                    ]
+                },
+            }
+        ),
+        content_type="application/json",
+    )
+
+    # Index page with navigation only
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://discourse.example.com/t/35.json",
+        body=json.dumps(
+            {
+                "id": 35,
+                "category_id": 2,
+                "title": "An index page",
+                "slug": "an-index-page",
+                "post_stream": {
+                    "posts": [
+                        {
+                            "id": 3435,
+                            "cooked": (
+                                "<p>Some homepage content</p>"
+                                "<h1>Navigation</h1>"
+                                "<ul>"
+                                '<li><a href="/t/page-a/10">Page A</a></li>'
+                                '<li><a href="/t/b-page/12">B page</a></li>'
+                                "</ul>"
+                            ),
+                            "updated_at": "2018-10-02T12:45:44.259Z",
+                        }
+                    ]
+                },
+            }
+        ),
+        content_type="application/json",
+    )
+
+    # Index page with broken, clashing url map and redirects
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://discourse.example.com/t/36.json",
+        body=json.dumps(
+            {
+                "id": 36,
+                "category_id": 2,
+                "title": "An index page",
+                "slug": "an-index-page",
+                "post_stream": {
+                    "posts": [
+                        {
+                            "id": 3436,
+                            "cooked": (
+                                "<p>Some homepage content</p>"
+                                "<h1>Navigation</h1>"
+                                "<ul>"
+                                '<li><a href="/t/page-a/10">Page A</a></li>'
+                                '<li><a href="/t/b-page/12">B page</a></li>'
+                                "</ul>"
+                                "<h1>URLs</h1>"
+                                '<details open="">'
+                                "<summary>Mapping table</summary>"
+                                '<div class="md-table">'
+                                "<table>"
+                                "<thead><tr>"
+                                "<th>Topic</th><th>Path</th></tr></thead>"
+                                "<tbody><tr>"
+                                '<td><a href="https://discourse.example.com/t'
+                                '/page-a/10">Page A</a></td>'
+                                "<td>/a</td>"
+                                "</tr><tr>"
+                                '<td><a href="https://discourse.example.com/t'
+                                '/page-z/26">Page Z</a></td>'
+                                "<td>/page-z</td>"
+                                "</tr></tbody></table>"
+                                "</div></details>"
+                                "<h1>Redirects</h1>"
+                                '<details open="">'
+                                "<summary>Mapping table</summary>"
+                                '<div class="md-table">'
+                                "<table>"
+                                "<thead><tr>"
+                                "<th>Path</th><th>Location</th></tr></thead>"
+                                "<tbody>"
+                                "<tr>"
+                                "  <td>/a</td><td>/clashing-redirect</td>"
+                                "</tr>"
+                                "<tr>"
+                                "  <td>invalid-path</td><td>/somewhere</td>"
+                                "</tr>"
+                                "<tr>"
+                                "  <td>/invalid-location</td>"
+                                "  <td>some-domain.com/fish</td>"
+                                "</tr>"
+                                "<tr>"
+                                "  <td>/valid</td>"
+                                "  <td>/target</td>"
+                                "</tr>"
+                                "</tbody></table>"
                                 "</div></details>"
                             ),
                             "updated_at": "2018-10-02T12:45:44.259Z",


### PR DESCRIPTION
Just like with the "URLs" section, this adds support for a "Redirects" section, which will contain a mapping table of "path"s to "location"s for defining redirect mappings.

The format for this section is described here:

https://github.com/nottrobin/canonicalwebteam.discourse-docs/blob/b86df3ccfb779c4f4033d5714d94312b667114b0/canonicalwebteam/discourse_docs/parsers.py#L96-L126

If an invalid redirect is encountered, ["Warning" HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Warning) will be sent. This will also happen if one of the redirect paths clashes with one of the pretty URLs in the URLs map.

QA
--

The simplest way to review this at this stage is to read the tests, check they make sense, and then check they pass:

https://github.com/nottrobin/canonicalwebteam.discourse-docs/blob/b86df3ccfb779c4f4033d5714d94312b667114b0/tests/test_app.py#L298-L331

These tests use the response code in these fixtures:

https://github.com/nottrobin/canonicalwebteam.discourse-docs/blob/b86df3ccfb779c4f4033d5714d94312b667114b0/tests/fixtures/forum_mock.py#L48-L62

https://github.com/nottrobin/canonicalwebteam.discourse-docs/blob/b86df3ccfb779c4f4033d5714d94312b667114b0/tests/fixtures/forum_mock.py#L142-L165

It can then be tested with an actual application when it gets added to the application, after this PR is merged.