### PR TITLE
Redirect instead of 404 for non 'doc' topics

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,3 +2,4 @@ v0.1.0, 2019-04-09 -- Create the extension from code in docs.snapcraft.io
 v0.1.1, 2019-04-11 -- Rename from "docs" to "discourse-docs", rename DiscourseDocs to DiscourseAPI
 v0.2.0, 2019-04-30 -- Restructure to simplify DiscourseAPI and create parsers.py
 v0.3.0, 2019-05-15 -- Support redirects mapping table in the index topic
+v0.4.0, 2019-05-17 -- Redirect to forum topic page instead of 404 for topics outside "docs" category

--- a/canonicalwebteam/discourse_docs/app.py
+++ b/canonicalwebteam/discourse_docs/app.py
@@ -69,10 +69,11 @@ class DiscourseDocs(object):
                 except HTTPError as http_error:
                     return flask.abort(http_error.response.status_code)
 
-                if category_id and topic["category_id"] != category_id:
-                    return flask.abort(404)
-
                 document = parse_topic(topic)
+
+                if category_id and topic["category_id"] != category_id:
+                    forum_topic_url = f'{api.base_url}{document["topic_path"]}'
+                    return flask.redirect(forum_topic_url)
 
                 if (
                     topic_id not in index["url_map"]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse_docs",
-    version="0.3.0",
+    version="0.4.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -351,7 +351,24 @@ class TestApp(unittest.TestCase):
 
         response = self.client.get("/t/b-page/50")
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.location, "https://discourse.example.com/t/b-page/50"
+        )
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client.get("/b-page/50")
+
+        self.assertEqual(
+            response.location, "https://discourse.example.com/t/b-page/50"
+        )
+        self.assertEqual(response.status_code, 302)
+
+        response = self.client.get("/50")
+
+        self.assertEqual(
+            response.location, "https://discourse.example.com/t/b-page/50"
+        )
+        self.assertEqual(response.status_code, 302)
 
     def test_missing_nav(self):
         """


### PR DESCRIPTION
# Done
When a user tries to access a topic that does not belong to the docs category, he is now redirected to the topic on the forum.

# QA
- Checkout master on `docs.snapcraft.io`.
- In the requirements file do:
```
-canonicalwebteam.discourse-docs==0.3.0
+git+https://github.com/jpmartinspt/canonicalwebteam.discourse-docs.git@redirect_instead_404#egg=canonicalwebteam.discourse-docs
```

- Go to http://0.0.0.0:8030/11365 and make sure you are redirected to `forum.snapcraft.io/t/multipass-does-not-start-on-ubuntu-server-18-04/11365`
- Go to http://0.0.0.0:8030/multipass-does-not-start-on-ubuntu-server-18-04/11365 and make sure you are redirected to `forum.snapcraft.io/t/multipass-does-not-start-on-ubuntu-server-18-04/11365`
- Go to http://0.0.0.0:8030/multipass-does-not-start-on-ubuntu-server-18-04 and make sure you are redirected to `forum.snapcraft.io/t/multipass-does-not-start-on-ubuntu-server-18-04/11365`
- Feel free to try with other topics and also double check all still works fine for the docs category topics.