### PR TITLE
parser.parse

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,3 +5,4 @@ v0.3.0, 2019-05-15 -- Support redirects mapping table in the index topic
 v0.4.0, 2019-05-17 -- Redirect to forum topic page instead of 404 for topics outside "docs" category
 v0.4.1, 2019-06-25 -- Fix url_prefix bugs
 v0.5.0, 2019-07-02 -- Thoroughly fix URL prefix
+v0.6.0, 2019-07-16 -- Make the parser as parameter to docs

--- a/canonicalwebteam/discourse_docs/__init__.py
+++ b/canonicalwebteam/discourse_docs/__init__.py
@@ -1,2 +1,3 @@
 from canonicalwebteam.discourse_docs.app import DiscourseDocs  # noqa
 from canonicalwebteam.discourse_docs.models import DiscourseAPI  # noqa
+from canonicalwebteam.discourse_docs.parsers import DocParser  # noqa

--- a/canonicalwebteam/discourse_docs/app.py
+++ b/canonicalwebteam/discourse_docs/app.py
@@ -44,31 +44,31 @@ class DiscourseDocs(object):
             parser = self.parser.parse()
 
             if path == "/":
-                document = parser.index_document
+                document = self.parser.index_document
             else:
                 try:
-                    topic_id = parser.resolve_path(path)
+                    topic_id = self.parser.resolve_path(path)
                 except RedirectFoundError as redirect:
                     return flask.redirect(redirect.target_url)
                 except PathNotFoundError:
                     return flask.abort(404)
 
-                if topic_id == parser.index_topic_id:
+                if topic_id == self.parser.index_topic_id:
                     return flask.redirect(self.url_prefix)
 
                 try:
-                    topic = api.get_topic(topic_id)
+                    topic = parser.api.get_topic(topic_id)
                 except HTTPError as http_error:
                     return flask.abort(http_error.response.status_code)
 
-                document = parser.parse_topic(topic)
+                document = self.parser.parse_topic(topic)
 
                 if category_id and topic["category_id"] != category_id:
-                    forum_topic_url = f'{api.base_url}{document["topic_path"]}'
+                    forum_topic_url = f'{parser.api.base_url}{document["topic_path"]}'
                     return flask.redirect(forum_topic_url)
 
                 if (
-                    topic_id not in parser.url_map
+                    topic_id not in self.parser.url_map
                     and document["topic_path"] != path
                 ):
                     return flask.redirect(document["topic_path"])
@@ -77,12 +77,12 @@ class DiscourseDocs(object):
                 flask.render_template(
                     document_template,
                     document=document,
-                    navigation=parser.navigation,
-                    forum_url=api.base_url,
+                    navigation=self.parser.navigation,
+                    forum_url=parser.api.base_url,
                 )
             )
 
-            for message in parser.warnings:
+            for message in self.parser.warnings:
                 flask.current_app.logger.warning(message)
                 response.headers.add(
                     "Warning",

--- a/canonicalwebteam/discourse_docs/app.py
+++ b/canonicalwebteam/discourse_docs/app.py
@@ -5,7 +5,6 @@ from canonicalwebteam.discourse_docs.exceptions import (
     PathNotFoundError,
     RedirectFoundError,
 )
-from canonicalwebteam.discourse_docs.parsers import DocParser
 
 
 class DiscourseDocs(object):
@@ -24,14 +23,14 @@ class DiscourseDocs(object):
 
     def __init__(
         self,
-        api,
-        index_topic_id,
+        parser,
         category_id,
         document_template="docs/document.html",
         url_prefix="/docs",
     ):
         self.blueprint = flask.Blueprint("discourse_docs", __name__)
         self.url_prefix = url_prefix
+        self.parser = parser
 
         @self.blueprint.route("/")
         @self.blueprint.route("/<path:path>")
@@ -42,7 +41,7 @@ class DiscourseDocs(object):
             """
 
             path = "/" + path
-            parser = DocParser(api, index_topic_id, self.url_prefix)
+            parser = self.parser.parse()
 
             if path == "/":
                 document = parser.index_document
@@ -54,7 +53,7 @@ class DiscourseDocs(object):
                 except PathNotFoundError:
                     return flask.abort(404)
 
-                if topic_id == index_topic_id:
+                if topic_id == parser.index_topic_id:
                     return flask.redirect(self.url_prefix)
 
                 try:

--- a/canonicalwebteam/discourse_docs/app.py
+++ b/canonicalwebteam/discourse_docs/app.py
@@ -41,7 +41,7 @@ class DiscourseDocs(object):
             """
 
             path = "/" + path
-            parser = self.parser.parse()
+            self.parser.parse()
 
             if path == "/":
                 document = self.parser.index_document
@@ -57,14 +57,16 @@ class DiscourseDocs(object):
                     return flask.redirect(self.url_prefix)
 
                 try:
-                    topic = parser.api.get_topic(topic_id)
+                    topic = self.parser.api.get_topic(topic_id)
                 except HTTPError as http_error:
                     return flask.abort(http_error.response.status_code)
 
                 document = self.parser.parse_topic(topic)
 
                 if category_id and topic["category_id"] != category_id:
-                    forum_topic_url = f'{parser.api.base_url}{document["topic_path"]}'
+                    forum_topic_url = (
+                        f'{parser.api.base_url}{document["topic_path"]}'
+                    )
                     return flask.redirect(forum_topic_url)
 
                 if (
@@ -78,7 +80,7 @@ class DiscourseDocs(object):
                     document_template,
                     document=document,
                     navigation=self.parser.navigation,
-                    forum_url=parser.api.base_url,
+                    forum_url=self.parser.api.base_url,
                 )
             )
 

--- a/canonicalwebteam/discourse_docs/parsers.py
+++ b/canonicalwebteam/discourse_docs/parsers.py
@@ -25,8 +25,8 @@ TOPIC_URL_MATCH = re.compile(
 class DocParser:
     def __init__(self, api, index_topic_id, url_prefix):
         self.api = api
-        self.url_prefix = url_prefix
         self.index_topic_id = index_topic_id
+        self.url_prefix = url_prefix
 
     def parse(self):
         """
@@ -37,7 +37,6 @@ class DocParser:
         - redirects map
         And set those as properties on this object
         """
-
         index_topic = self.api.get_topic(self.index_topic_id)
         raw_index_soup = BeautifulSoup(
             index_topic["post_stream"]["posts"][0]["cooked"],

--- a/canonicalwebteam/discourse_docs/parsers.py
+++ b/canonicalwebteam/discourse_docs/parsers.py
@@ -28,7 +28,17 @@ class DocParser:
         self.url_prefix = url_prefix
         self.index_topic_id = index_topic_id
 
-        index_topic = self.api.get_topic(index_topic_id)
+    def parse(self):
+        """
+        Get the index topic and split it into:
+        - navigation
+        - index document content
+        - URL map
+        - redirects map
+        And set those as properties on this object
+        """
+
+        index_topic = self.api.get_topic(self.index_topic_id)
         raw_index_soup = BeautifulSoup(
             index_topic["post_stream"]["posts"][0]["cooked"],
             features="html.parser",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse_docs",
-    version="0.5.0",
+    version="0.6.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,7 +9,7 @@ import httpretty
 from bs4 import BeautifulSoup
 
 # Local
-from canonicalwebteam.discourse_docs import DiscourseDocs, DiscourseAPI
+from canonicalwebteam.discourse_docs import DiscourseDocs, DiscourseAPI, DocParser
 from tests.fixtures.forum_mock import register_uris
 
 
@@ -49,33 +49,37 @@ class TestApp(unittest.TestCase):
         app_no_mappings.testing = True
         app_broken_mappings.testing = True
 
+        discourse_api = DiscourseAPI(base_url="https://discourse.example.com/")
+        discourse_parser = DocParser(discourse_api, 34, "/")
         DiscourseDocs(
-            api=DiscourseAPI(base_url="https://discourse.example.com/"),
-            index_topic_id=34,
+            parser=discourse_parser,
             category_id=2,
             document_template="document.html",
             url_prefix="/",
         ).init_app(app)
 
+        discourse_api = DiscourseAPI(base_url="https://discourse.example.com/")
+        discourse_parser = DocParser(discourse_api, 42, "/")
         DiscourseDocs(
-            api=DiscourseAPI(base_url="https://discourse.example.com/"),
-            index_topic_id=42,
+            parser=discourse_parser,
             category_id=2,
             document_template="document.html",
             url_prefix="/",
         ).init_app(app_no_nav)
 
+        discourse_api = DiscourseAPI(base_url="https://discourse.example.com/")
+        discourse_parser = DocParser(discourse_api, 35, "/")
         DiscourseDocs(
-            api=DiscourseAPI(base_url="https://discourse.example.com/"),
-            index_topic_id=35,
+            parser=discourse_parser,
             category_id=2,
             document_template="document.html",
             url_prefix="/",
         ).init_app(app_no_mappings)
 
+        discourse_api = DiscourseAPI(base_url="https://discourse.example.com/")
+        discourse_parser = DocParser(discourse_api, 36, "/")
         DiscourseDocs(
-            api=DiscourseAPI(base_url="https://discourse.example.com/"),
-            index_topic_id=36,
+            parser=discourse_parser,
             category_id=2,
             document_template="document.html",
             url_prefix="/",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,7 +9,11 @@ import httpretty
 from bs4 import BeautifulSoup
 
 # Local
-from canonicalwebteam.discourse_docs import DiscourseDocs, DiscourseAPI, DocParser
+from canonicalwebteam.discourse_docs import (
+    DiscourseDocs,
+    DiscourseAPI,
+    DocParser,
+)
 from tests.fixtures.forum_mock import register_uris
 
 


### PR DESCRIPTION
Pass DocParser to DiscourseDocs, so that it can be used outside by client projects.