### PR TITLE
v0.6.1: /sitemap.txt

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,3 +6,4 @@ v0.4.0, 2019-05-17 -- Redirect to forum topic page instead of 404 for topics out
 v0.4.1, 2019-06-25 -- Fix url_prefix bugs
 v0.5.0, 2019-07-02 -- Thoroughly fix URL prefix
 v0.6.0, 2019-07-16 -- Make the parser as parameter to docs
+v0.6.0, 2019-07-16 -- Add /sitemap.txt

--- a/canonicalwebteam/discourse_docs/app.py
+++ b/canonicalwebteam/discourse_docs/app.py
@@ -32,6 +32,22 @@ class DiscourseDocs(object):
         self.url_prefix = url_prefix
         self.parser = parser
 
+        @self.blueprint.route("/sitemap.txt")
+        def sitemap_view():
+            """
+            Show a list of all URLs in the URL map
+            """
+
+            self.parser.parse()
+
+            urls = []
+
+            for key, value in self.parser.url_map.items():
+                if type(key) is str:
+                    urls.append(key)
+
+            return "\n".join(urls)
+
         @self.blueprint.route("/")
         @self.blueprint.route("/<path:path>")
         def document_view(path=""):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse_docs",
-    version="0.6.0",
+    version="0.6.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -441,3 +441,13 @@ class TestApp(unittest.TestCase):
 
         self.assertEqual("A notification", note_contents)
         self.assertEqual("A warning", warn_contents)
+
+    def test_sitemap(self):
+        """
+        Check we can retrieve a list of all URLs in the URL map at
+        /sitemap.txt
+        """
+
+        response = self.client.get("/sitemap.txt")
+
+        self.assertEqual(b"/a\n/page-z\n/", response.data)


### PR DESCRIPTION
Add a `/sitemap.txt` endpoint which will lists all the URLs in the URL map.

This will help with getting our docs URLs indexed by Google (for a longer explanation see https://github.com/canonical-web-and-design/maas.io/pull/370)

QA
--

`./setup test` - See the `test_sitemap` test pass.