### PR TITLE
Add sections to context

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,3 +11,4 @@ v0.6.2, 2019-07-26 -- Add content type for sitemap.txt
 v0.6.3, 2019-07-29 -- Ensure sitemap.txt is utf-8 content-type
 v0.6.4, 2019-07-29 -- Add domain to URLs in /sitemap.txt
 v0.6.5, 2019-12-12 -- Add optional name parameter to be able to have multiple blueprints
+v0.7.0, 2019-12-19 -- Add sections divided by h2 in context

--- a/canonicalwebteam/discourse_docs/parsers.py
+++ b/canonicalwebteam/discourse_docs/parsers.py
@@ -524,6 +524,7 @@ class DocParser:
                 first_child.extract()
 
             section["title"] = heading.text
+            section["slug"] = heading.text.lower().replace(" ", "-")
             section["content"] = str(section_soup)
             sections.append(section)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse_docs",
-    version="0.6.5",
+    version="0.7.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",


### PR DESCRIPTION
# Summary

- Add in context the the var sections that gives a split of the `body_html` by h2
- bump to v0.7.0

# QA

- pull locally `ubuntu.com`
- add in the requirements.txt of ubuntu.com:
```
-e git+https://github.com/tbille/canonicalwebteam.docs.git@add-sections#egg=canonicalwebteam.discourse-docs
```
- in the file `webapp/app.py`
```py
url_prefix = "/tutorials"
tutorials_docs_parser = DocParser(
    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
    index_topic_id=13611,
    url_prefix=url_prefix,
)
tutorials_docs = DiscourseDocs(
    parser=tutorials_docs_parser,
    category_id=34,
    document_template="/docs/document.html",
    url_prefix=url_prefix,
    blueprint_name="tutorials",
)

tutorials_docs.init_app(app)
```

-  on the file: `/templates/docs/document.html`
```
-        {{ document.body_html | safe }}
+        {% for section in document.sections %}
+          <h2>{{ section["title"] }}</h2>
+          <p>Duration: {{ section["duration"] }}</p>
+          {{ section.content | safe }}
+        {% endfor %}
```
- `./run`
- go on http://127.0.0.1:8001/tutorials/tutorial-install-ubuntu-desktop
- Make sure it's the correct data (you can also try by not changing the template file
