### PR TITLE
Add remaning duration

### DIFF
--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+discourse


### PR DESCRIPTION
# Summary

- Add in context the the var sections that gives a split of the `body_html` by h2
- bump to v0.7.0

# QA

- pull locally `ubuntu.com`
- add in the requirements.txt of ubuntu.com:
```
-e git+https://github.com/tbille/canonicalwebteam.docs.git@add-remaining-duration#egg=canonicalwebteam.discourse-docs
```
- in the file `webapp/app.py`
```py
url_prefix = "/tutorials"
tutorials_docs_parser = DocParser(
    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
    index_topic_id=13611,
    url_prefix=url_prefix,
)
tutorials_docs = DiscourseDocs(
    parser=tutorials_docs_parser,
    category_id=34,
    document_template="/docs/document.html",
    url_prefix=url_prefix,
    blueprint_name="tutorials",
)

tutorials_docs.init_app(app)
```

-  on the file: `/templates/docs/document.html`
```
-        {{ document.body_html | safe }}
+        {% for section in document.sections %}
+          <h2>{{ section["title"] }}</h2>
+          <p>Remaining Duration: {{ section["remaining_duration"] }}</p>
+          {{ section.content | safe }}
+        {% endfor %}
```
- `./run`
- go on http://127.0.0.1:8001/tutorials/tutorial-install-ubuntu-desktop
- Make sure it's the correct data (you can also try by not changing the template file
