### PR TITLE
Add metadata parsing

### DIFF
--- a/canonicalwebteam/discourse_docs/app.py
+++ b/canonicalwebteam/discourse_docs/app.py
@@ -101,6 +101,7 @@ class DiscourseDocs(object):
                     document=document,
                     navigation=self.parser.navigation,
                     forum_url=self.parser.api.base_url,
+                    metadata=self.parser.metadata,
                 )
             )
 


### PR DESCRIPTION
# Summary

- Add in context the metadata read from the discourse index: https://discourse.ubuntu.com/t/about-the-tutorials-category/13611

The idea here is that you can have a undefined number of column and the parser will create a list of dictionaries with the keys based on the column name. 

# QA

- pull locally `ubuntu.com`
- add in the requirements.txt of ubuntu.com:
```
-e git+https://github.com/tbille/canonicalwebteam.docs.git@add-metadata-parsing#egg=canonicalwebteam.discourse-docs
```
- in the file `webapp/app.py`
```py
url_prefix = "/tutorials"
tutorials_docs_parser = DocParser(
    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
    index_topic_id=13611,
    url_prefix=url_prefix,
)
tutorials_docs = DiscourseDocs(
    parser=tutorials_docs_parser,
    category_id=34,
    document_template="/docs/document.html",
    url_prefix=url_prefix,
    blueprint_name="tutorials",
)

tutorials_docs.init_app(app)
```

-  on the file: `/templates/docs/document.html`
```
-        {{ document.body_html | safe }}
+        {{ metadata }}
```
- `./run`
- go on http://127.0.0.1:8001/tutorials/tutorial-install-ubuntu-desktop
- go on http://127.0.0.1:8001/tutorials/
- Make sure you have the metadata as an array of dicts
