### PR TITLE
Set commit id for GH Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       run: python3 setup.py sdist bdist_wheel
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@e777b33388fefa46ce597d8afa9c15a5357af36f
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
We agreed to should use an specific commit ID for the GitHub Action "gh-action-pypi-publish" to avoid issues like this one: https://github.com/pypa/gh-action-pypi-publish/issues/20