### PR TITLE
Fix parsing duration

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,3 +13,4 @@ v0.6.4, 2019-07-29 -- Add domain to URLs in /sitemap.txt
 v0.6.5, 2019-12-12 -- Add optional name parameter to be able to have multiple blueprints
 v0.7.0, 2019-12-19 -- Add sections divided by h2 in context
 v0.8.0, 2020-01-10 -- Add metadata parsing from index topic
+v0.8.1, 2020-01-14 -- Fix time parsing HH:MM to MM:SS

--- a/canonicalwebteam/discourse_docs/parsers.py
+++ b/canonicalwebteam/discourse_docs/parsers.py
@@ -8,6 +8,7 @@ import dateutil.parser
 import humanize
 import validators
 from bs4 import BeautifulSoup
+from datetime import datetime, timedelta
 from jinja2 import Template
 
 # Local
@@ -578,7 +579,7 @@ class DocParser:
         headings = soup.findAll("h2")
 
         sections = []
-        total_duration = 0
+        total_duration = datetime.strptime("00:00", "%M:%S")
 
         for heading in headings:
             section = {}
@@ -590,8 +591,10 @@ class DocParser:
                 )
 
                 try:
-                    dt = dateutil.parser.parse(section["duration"])
-                    total_duration += (dt.hour * 60) + dt.minute
+                    dt = datetime.strptime(section["duration"], "%M:%S")
+                    total_duration += timedelta(
+                        minutes=dt.minute, seconds=dt.second
+                    )
                 except Exception:
                     pass
 
@@ -610,9 +613,11 @@ class DocParser:
         for section in sections:
             if "duration" in section:
                 try:
-                    dt = dateutil.parser.parse(section["duration"])
-                    total_duration -= (dt.hour * 60) + dt.minute
-                    section["remaining_duration"] = total_duration
+                    dt = datetime.strptime(section["duration"], "%M:%S")
+                    total_duration -= timedelta(
+                        minutes=dt.minute, seconds=dt.second
+                    )
+                    section["remaining_duration"] = total_duration.minute
                 except Exception:
                     pass
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse_docs",
-    version="0.8.0",
+    version="0.8.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",


### PR DESCRIPTION
Mistake was done. The duration in tutorails is MM:SS not HH:MM

# QA

- pull locally `ubuntu.com`
- add in the requirements.txt of ubuntu.com:
```
-e git+https://github.com/tbille/canonicalwebteam.docs.git@fix-timeparsing#egg=canonicalwebteam.discourse-docs
```