### PR TITLE
Parse categories api to get correct urls

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,3 +14,4 @@ v0.6.5, 2019-12-12 -- Add optional name parameter to be able to have multiple bl
 v0.7.0, 2019-12-19 -- Add sections divided by h2 in context
 v0.8.0, 2020-01-10 -- Add metadata parsing from index topic
 v0.8.1, 2020-01-14 -- Fix time parsing HH:MM to MM:SS
+v0.9.0, 2020-01-15 -- Add categories list parsing

--- a/canonicalwebteam/discourse_docs/app.py
+++ b/canonicalwebteam/discourse_docs/app.py
@@ -24,7 +24,6 @@ class DiscourseDocs(object):
     def __init__(
         self,
         parser,
-        category_id,
         document_template="docs/document.html",
         url_prefix="/docs",
         blueprint_name="discourse_docs",
@@ -32,6 +31,7 @@ class DiscourseDocs(object):
         self.blueprint = flask.Blueprint(blueprint_name, __name__)
         self.url_prefix = url_prefix
         self.parser = parser
+        category_id = self.parser.category_id
 
         @self.blueprint.route("/sitemap.txt")
         def sitemap_view():

--- a/canonicalwebteam/discourse_docs/models.py
+++ b/canonicalwebteam/discourse_docs/models.py
@@ -30,3 +30,11 @@ class DiscourseAPI:
         response.raise_for_status()
 
         return response.json()
+
+    def get_topics_category(self, category_id, page=0):
+        response = self.session.get(
+            f"{self.base_url}/c/{category_id}.json?page={page}"
+        )
+        response.raise_for_status()
+
+        return response.json()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse_docs",
-    version="0.8.1",
+    version="0.9.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",

--- a/tests/fixtures/forum_mock.py
+++ b/tests/fixtures/forum_mock.py
@@ -329,3 +329,22 @@ def register_uris():
         status=404,
         content_type="application/json",
     )
+
+    httpretty.register_uri(
+        httpretty.GET,
+        "https://discourse.example.com/c/2.json",
+        body=json.dumps(
+            {
+                "topic_list": {
+                    "per_page": 3,
+                    "topics": [
+                        {
+                            "id": 3434,
+                            "slug": "super-fancy",
+                            "fancy_title": "Super fancy",
+                        }
+                    ],
+                }
+            }
+        ),
+    )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -54,37 +54,33 @@ class TestApp(unittest.TestCase):
         app_broken_mappings.testing = True
 
         discourse_api = DiscourseAPI(base_url="https://discourse.example.com/")
-        discourse_parser = DocParser(discourse_api, 34, "/")
+        discourse_parser = DocParser(discourse_api, 2, 34, "/")
         DiscourseDocs(
             parser=discourse_parser,
-            category_id=2,
             document_template="document.html",
             url_prefix="/",
         ).init_app(app)
 
         discourse_api = DiscourseAPI(base_url="https://discourse.example.com/")
-        discourse_parser = DocParser(discourse_api, 42, "/")
+        discourse_parser = DocParser(discourse_api, 2, 42, "/")
         DiscourseDocs(
             parser=discourse_parser,
-            category_id=2,
             document_template="document.html",
             url_prefix="/",
         ).init_app(app_no_nav)
 
         discourse_api = DiscourseAPI(base_url="https://discourse.example.com/")
-        discourse_parser = DocParser(discourse_api, 35, "/")
+        discourse_parser = DocParser(discourse_api, 2, 35, "/")
         DiscourseDocs(
             parser=discourse_parser,
-            category_id=2,
             document_template="document.html",
             url_prefix="/",
         ).init_app(app_no_mappings)
 
         discourse_api = DiscourseAPI(base_url="https://discourse.example.com/")
-        discourse_parser = DocParser(discourse_api, 36, "/")
+        discourse_parser = DocParser(discourse_api, 2, 36, "/")
         DiscourseDocs(
             parser=discourse_parser,
-            category_id=2,
             document_template="document.html",
             url_prefix="/",
         ).init_app(app_broken_mappings)


### PR DESCRIPTION
# Summary

- It seems that dicsourse when having to many internal links struggles to get the title of a topic. (eg. https://discourse.ubuntu.com/t/about-the-tutorials-category/13611 )
- To fix this, I call the category api and loop through it to get all the topics of a category (since not possible to make a unique api call I have to loop until I reach the end. https://docs.discourse.org/#tag/Categories/paths/~1c~1{id}.json/get )
- Then I go through the soup  and replace the text in every `a` tag

 This is a breaking change since the category id is no part of the parser

# QA

- pull locally `ubuntu.com`
- add in the requirements.txt of ubuntu.com:
```
-e git+https://github.com/tbille/canonicalwebteam.docs.git@parse-categories#egg=canonicalwebteam.discourse-docs
```
- in the file `webapp/app.py`
```py
url_prefix = "/server/docs"
server_docs_parser = DocParser(
    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
    category_id=26,
    index_topic_id=11322,
    url_prefix=url_prefix,
)
server_docs = DiscourseDocs(
    parser=server_docs_parser,
    document_template="/docs/document.html",
    url_prefix=url_prefix,
)

server_docs.init_app(app)

url_prefix = "/tutorials"
tutorials_docs_parser = DocParser(
    api=DiscourseAPI(base_url="https://discourse.ubuntu.com/"),
    category_id=34,
    index_topic_id=13611,
    url_prefix=url_prefix,
)
tutorials_docs = DiscourseDocs(
    parser=tutorials_docs_parser,
    document_template="/tutorials/tutorial.html",
    url_prefix=url_prefix,
    blueprint_name="tutorials",
)

```
- `./run`
- make sure urls for tutorials are correct
