### PR TITLE
Fix AttributeError in some docs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,3 +20,4 @@ v0.10.1, 2020-01-17 -- Add test for category not existing
 v0.10.2, 2020-01-24 -- Fix slug non alpha numerical issue
 v0.10.3, 2020-02-06 -- Fix check if undefined values
 v0.11.0, 2020-02-04 -- Add poll conversion
+v0.11.1, 2020-02-14 -- Fix AttributeError issue

--- a/canonicalwebteam/discourse_docs/parsers.py
+++ b/canonicalwebteam/discourse_docs/parsers.py
@@ -685,7 +685,8 @@ class DocParser:
         for heading in headings:
             section = {}
             section_soup = self._get_section(soup, heading.text)
-            first_child = section_soup.find()
+            first_child = section_soup.find() if section_soup else None
+
             if first_child and first_child.text.startswith("Duration"):
                 section["duration"] = first_child.text.replace(
                     "Duration: ", ""

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse_docs",
-    version="0.11.0",
+    version="0.11.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",


### PR DESCRIPTION
Fixes https://github.com/canonical-web-and-design/snapcraft.io/issues/2517 and https://github.com/canonical-web-and-design/snapcraft.io/issues/2516

The last version of this module has created an AttributeError issue in some of Snapcraft.io doc pages, eg:
https://snapcraft.io/docs/supported-snap-hooks
https://snapcraft.io/docs/writing-local-plugins

This change fixes the issue.

# QA
Follow the QA in this PR:
https://github.com/canonical-web-and-design/snapcraft.io/pull/2520