### PR TITLE
Fix micro8s.io/docs/addon-ambassador 500 error

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,4 +23,4 @@ v0.11.0, 2020-02-04 -- Add poll conversion
 v0.11.1, 2020-02-14 -- Fix AttributeError issue
 v0.12.0, 2020-05-15 -- Make category_id optional
 v1.0.0, 2020-06-03 -- Make session mandatory; stop using canonicalwebteam.http.CachedSession
-v0.10.2, 2020-07-15 -- Only strip space when there is space to strip
+v1.0.1, 2020-07-15 -- Only strip space when there is space to strip

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,3 +23,4 @@ v0.11.0, 2020-02-04 -- Add poll conversion
 v0.11.1, 2020-02-14 -- Fix AttributeError issue
 v0.12.0, 2020-05-15 -- Make category_id optional
 v1.0.0, 2020-06-03 -- Make session mandatory; stop using canonicalwebteam.http.CachedSession
+v0.10.2, 2020-07-15 -- Only strip space when there is space to strip

--- a/canonicalwebteam/discourse_docs/parsers.py
+++ b/canonicalwebteam/discourse_docs/parsers.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse, urlunparse
 import dateutil.parser
 import humanize
 import validators
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString
 from datetime import datetime, timedelta
 from jinja2 import Template
 
@@ -646,7 +646,8 @@ class DocParser:
 
                 # Strip leading space
                 first_item = last_paragraph.contents[0]
-                first_item.replace_with(first_item.lstrip(" "))
+                if isinstance(first_item, NavigableString):
+                    first_item.replace_with(first_item.lstrip(" "))
 
                 notification = notification_template.render(
                     notification_class="p-notification--caution",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.discourse_docs",
-    version="1.0.0",
+    version="1.0.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/canonicalwebteam.docs",


### PR DESCRIPTION
## Done

microk8s.io/docs/addon-ambassador returns NoneType because there is no space to strip, it starts with a emoticon. So added a condition for that.

## QA

QA in microk8s, make sure <https://microk8s.io/docs/addon-ambassador> is accessible

## Issues

Fixes #41 
Fixes https://github.com/canonical-web-and-design/microk8s.io/issues/300